### PR TITLE
Disabled clone depth for sonar analysis.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -125,6 +125,9 @@ script: "wget -q -O - https://raw.githubusercontent.com/mizool/travis-ci-maven-g
 cache:
   directories:
   - "$HOME/.m2/repository"
+
+git:
+  depth: false
 ----
 +
 . Place your `codesigning.asc.enc` into the root of your repository (see <<Creating a codesigning certificate>> if


### PR DESCRIPTION
To allow sonar to blame correctly, we need non-shallow clones.
See https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth for details.